### PR TITLE
fix: remove '@' when linking as a URL

### DIFF
--- a/src/functions/groups.rs
+++ b/src/functions/groups.rs
@@ -120,7 +120,10 @@ pub fn keyboard_detail(page: i32, data: &Option<Group>) -> InlineKeyboardMarkup 
 
     if let Some(group) = data {
         keyboard
-            .url("Telegram", &format!("https://t.me/{}", group.telegram))
+            .url(
+                "Telegram",
+                &format!("https://t.me/{}", &group.telegram[1..]),
+            )
             .unwrap();
 
         if group.link.is_some() {


### PR DESCRIPTION
`t.me/@chat_id` ends up with not found error